### PR TITLE
Prepublish script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/django-s3-file-upload",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/django-s3-file-upload",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Upload files from the browser to S3 - client side implementation",
   "main": "dist/index.js",
   "directories": {},


### PR DESCRIPTION
The last (initial) release did not have this script and therefore the dist directory did not contain the latest built code.