### PR TITLE
Typescript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/django-s3-file-upload",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/django-s3-file-upload",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Upload files from the browser to S3 - client side implementation",
   "main": "dist/index.js",
   "directories": {},


### PR DESCRIPTION
Due to a new syntax for readonly types, compiling with 3.4 was not backward compatible with 3.3

https://devblogs.microsoft.com/typescript/announcing-typescript-3-4/