### PR TITLE
ES5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ To install the package run:
 npm i @dabapps/django-s3-file-upload -S
 ```
 
+### Compatibility
+
+You will also need polyfills for both `Promises` and `Symbols` if you wish to target older browsers.
+
 ## Usage
 
 ### How it works

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/django-s3-file-upload",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prettier-check": "prettier --check '**/*.{ts,tsx,js,jsx}'",
     "prettier": "prettier --write '**/*.{ts,tsx,js,jsx}'",
     "tests": "jest",
-    "test": "npm run lint && npm run typecheck && npm run tests -- --runInBand --coverage",
+    "test": "npm run dist && npm run lint && npm run typecheck && npm run tests -- --runInBand --coverage",
     "prepublishOnly": "npm run dist"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/django-s3-file-upload",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Upload files from the browser to S3 - client side implementation",
   "main": "dist/index.js",
   "directories": {},

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -4,6 +4,13 @@
     "declaration": true,
     "sourceMap": true,
     "listEmittedFiles": true,
+    "target": "es5",
+    "lib": [
+      "es5",
+      "dom",
+      "es2015.promise",
+      "es2015.symbol"
+    ],
     "rootDir": "./src/",
     "outDir": "./dist/"
   },


### PR DESCRIPTION
We've been getting some `Unexpected token 'const'` errors due to targeting ES6 for dist.

This change ensures that these are compiled to ES5 compatible syntax.

Libs for promise and symbol have been added, and will require polyfills to work in older browsers.